### PR TITLE
Compile goof file to binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 output*
-tmp/
 tests/*.tmp
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ Table of Contents
 
 ## Idea
 
-I always wanted a self hosted compiler for my own language. The big picture is to build a simple computer catered for the langauge.
-The idea for this project stemmed from [Crafting Interpreters](https://www.craftinginterpreters.com/). But I believe the book spoon feeds the concepts and at the end you have an emulator program for running your language and not a native program that you can call independent. Hence bootstrapping through this route would have been very difficult.
+I always wanted a self hosted compiler for my own language. The big picture is to build my own simple computer catered for the langauge.
+
+The idea for this project stemmed from book [Crafting Interpreters](https://www.craftinginterpreters.com/). But I believe the book spoon feeds the concepts and at the end you have an emulator program. The compiler in the book depends on some existing runtime (Java and C).
+
+Hence bootstrapping through this route would have been very difficult.
 Majority of the project has been inspired from [tsoding](https://www.youtube.com/@TsodingDaily) and his [porth](https://www.youtube.com/playlist?list=PLpM-Dvs8t0VbMZA7wW9aR3EtBqe2kinu4) series which is a language like Forth but in python. I decided to write this in go for various reasons I find meaningful.
 
 ## Usage
+
+Currently only `x86_64 GNU/Linux` platform is supported.
 
 You would require the following for compiling the language to a 64 bit ELF executable file.
 - [go](https://go.dev/): at the time of writing, I have used `1.23.3` version
@@ -48,7 +53,6 @@ $ go run ./cmd/cli ./test.goof
 $ ./test
 42
 ```
-Currently this ELF executable can only be run on linux 64 bit systems (`x86_64` architecture)
 
 The compiled binary can be verified using `file` and `ldd` commands.
 ```shell
@@ -64,7 +68,7 @@ Other examples can be found in [/examples](./examples) directory which can be re
 ## TODOs
 - [x] Compiled
 - [x] Native
-- [x] Turing complete
+- [x] Turing complete, you can check [game of life](./examples/gol.goof) and [rule110](./examples/rule-110.goof) written in goof
 - [x] Static type checking, check reference [here](https://binji.github.io/posts/webassembly-type-checking/)
 - [x] Add editor config for vim / nvim for goof source files, check [vim.goof](./editor/vim.goof)
 - [x] Add local memory
@@ -80,7 +84,7 @@ Other examples can be found in [/examples](./examples) directory which can be re
     - [x] memory mapping file contents for self hosting parsing, check [ref](https://man7.org/linux/man-pages/man2/mmap.2.html), check [file-map.goof](./examples/file-map.goof)
     - [x] add support for parsing strings, say string.goof, check [ref](https://github.com/tsoding/sv), check [string.goof](./string.goof)
     - [x] parse goof file into operations instead of hardcoding the program
-    - [ ] run exec system call to execute nasm and ld, for producing final binary
+    - [ ] run exec system call to execute `nasm` and `ld`, for producing final binary
 - [ ] Deploy a static site with an online playground for compiling on the go
 - [ ] Include directories and add support for finding included files
 - [ ] Add library builtin functions
@@ -215,7 +219,7 @@ num 42 .
 
 - `,` - **load**: pops the memory address from stack and pushes the value present at that address (dereferences the memory address present on top of stack)
 ```pascal
-42 num ,
+num ,
 // push(mem[num])
 ```
 
@@ -236,6 +240,7 @@ end
 // call the proc like this
 hello dump // dump the int return from procedure
 ```
+- more complex procedures like the factorial procedure can be found in [recursive.goof](./examples/recursive.goof)
 
 #### System
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -78,7 +78,7 @@ func CompileToAsm(outputFilePath string, program []model.Operation) {
     out.WriteString("    mov [ret_stack_rsp], rax\n")
 
     ip := 0
-    if constants.COUNT_OPS != 56 {
+    if constants.COUNT_OPS != 57 {
         panic("Exhaustive handling in compilation")
     }
 
@@ -347,6 +347,15 @@ func CompileToAsm(outputFilePath string, program []model.Operation) {
             out.WriteString("    pop rdi\n")
             out.WriteString("    pop rsi\n")
             out.WriteString("    pop rdx\n")
+            out.WriteString("    syscall\n")
+            out.WriteString("    push rax\n")
+        case constants.OP_SYSCALL4:
+            out.WriteString("    ;; -- syscall --\n")
+            out.WriteString("    pop rax\n")
+            out.WriteString("    pop rdi\n")
+            out.WriteString("    pop rsi\n")
+            out.WriteString("    pop rdx\n")
+            out.WriteString("    pop r10\n")
             out.WriteString("    syscall\n")
             out.WriteString("    push rax\n")
         case constants.OP_SYSCALL6:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -78,7 +78,7 @@ func CompileToAsm(outputFilePath string, program []model.Operation) {
     out.WriteString("    mov [ret_stack_rsp], rax\n")
 
     ip := 0
-    if constants.COUNT_OPS != 55 {
+    if constants.COUNT_OPS != 56 {
         panic("Exhaustive handling in compilation")
     }
 
@@ -322,6 +322,11 @@ func CompileToAsm(outputFilePath string, program []model.Operation) {
             out.WriteString("    ;; -- argv --\n")
             out.WriteString("    mov rax, [args_ptr]\n")
             out.WriteString("    add rax, 8\n")
+            out.WriteString("    push rax\n")
+        case constants.OP_SYSCALL0:
+            out.WriteString("    ;; -- syscall --\n")
+            out.WriteString("    pop rax\n")
+            out.WriteString("    syscall\n")
             out.WriteString("    push rax\n")
         case constants.OP_SYSCALL1:
             out.WriteString("    ;; -- syscall --\n")

--- a/constants/operations.go
+++ b/constants/operations.go
@@ -47,6 +47,7 @@ const (
     OP_TYPE_INT
     OP_TYPE_PTR
     OP_TYPE_BOOL
+    OP_SYSCALL0
     OP_SYSCALL1
     OP_SYSCALL2
     OP_SYSCALL3
@@ -101,6 +102,7 @@ var BUILTIN_WORDS = map[string]int{
     "ptr": OP_TYPE_PTR,
     "bool": OP_TYPE_BOOL,
     "--": OP_PROC_SEP,
+    "syscall0": OP_SYSCALL0,
     "syscall1": OP_SYSCALL1,
     "syscall2": OP_SYSCALL2,
     "syscall3": OP_SYSCALL3,

--- a/constants/operations.go
+++ b/constants/operations.go
@@ -51,6 +51,7 @@ const (
     OP_SYSCALL1
     OP_SYSCALL2
     OP_SYSCALL3
+    OP_SYSCALL4
     OP_SYSCALL6
     OP_ARGV
     OP_ARGC
@@ -106,6 +107,7 @@ var BUILTIN_WORDS = map[string]int{
     "syscall1": OP_SYSCALL1,
     "syscall2": OP_SYSCALL2,
     "syscall3": OP_SYSCALL3,
+	"syscall4": OP_SYSCALL4,
     "syscall6": OP_SYSCALL6,
     "argv": OP_ARGV,
     "argc": OP_ARGC,

--- a/examples/cmd-echo.goof
+++ b/examples/cmd-echo.goof
@@ -1,0 +1,31 @@
+include "std.goof"
+
+const sizeof(ptr) 8 end
+const CMD_ARGS_SIZE 2 end
+
+memory cmd CMD_ARGS_SIZE sizeof(ptr) * end
+
+cmd 0 + "/usr/bin/echo\x00" swap drop .64
+cmd 8 + "hello world\x00" swap drop .64
+
+fork 
+if dup 0 = do
+    // child process (pid = 0)
+    "[CMD] " puts
+    0 while dup CMD_ARGS_SIZE < do
+        dup sizeof(ptr) * cmd + ,64 (ptr) 64 swap puts
+        " " puts
+        1 +
+    end
+    "\n" puts
+
+    // NULL ["/usr/bin/echo", "hello"] "echo"
+    0 cmd cmd ,64 59 syscall3 drop
+elif dup 0 > do
+    // parent process
+    "[TODO] waiting for child process is not implemented\n" eputs
+else
+    "[ERROR] could not fork a child process\n" eputs
+end
+drop
+

--- a/examples/cmd-echo.goof
+++ b/examples/cmd-echo.goof
@@ -4,26 +4,39 @@ const sizeof(ptr) 8 end
 const CMD_ARGS_SIZE 2 end
 
 memory cmd CMD_ARGS_SIZE sizeof(ptr) * end
+memory wstatus 64 end
 
-cmd 0 + "/usr/bin/echo\x00" swap drop .64
-cmd 8 + "hello world\x00" swap drop .64
+cmd 0 + "/usr/bin/sleep\x00" swap drop .64
+cmd 8 + "5\x00" swap drop .64
 
 fork 
 if dup 0 = do
     // child process (pid = 0)
     "[CMD] " puts
     0 while dup CMD_ARGS_SIZE < do
-        dup sizeof(ptr) * cmd + ,64 (ptr) 64 swap puts
+        dup sizeof(ptr) * cmd + ,64 (ptr) dup strlen swap puts
         " " puts
         1 +
     end
+    drop
     "\n" puts
 
     // NULL ["/usr/bin/echo", "hello"] "echo"
     0 cmd cmd ,64 59 syscall3 drop
 elif dup 0 > do
     // parent process
-    "[TODO] waiting for child process is not implemented\n" eputs
+    0
+    0
+    wstatus
+    -1
+    wait4
+    if dup 0 < do
+        "[ERROR] could not wait until the child process has finished executing\n" eputs
+        1 exit
+    end
+    drop
+
+    "[PARENT] waiting for child completes\n" eputs
 else
     "[ERROR] could not fork a child process\n" eputs
 end

--- a/goof.goof
+++ b/goof.goof
@@ -11,6 +11,7 @@ const OP_DUMP     3 end
 
 memory putd-buffer PUTD_BUFFER_CAP end
 memory fd          8 end
+memory outputfd    8 end
 memory statbuf     sizeof(stat) end
 memory content     sizeof(str) end
 memory line        sizeof(str) end
@@ -24,9 +25,9 @@ memory ops         0 end
 const sizeof(Op) 16 end
 
 // 10 -> "10"
-proc putd int -- --
+proc fputd int ptr -- --
     if dup 0 = do
-        "0" puts
+        "0" outputfd fputs
     else
         putd-buffer PUTD_BUFFER_CAP +
         // n ptr
@@ -40,7 +41,7 @@ proc putd int -- --
             48 + . swap
         end
         dup // n ptr len
-        putd-buffer PUTD_BUFFER_CAP + swap - swap puts
+        putd-buffer PUTD_BUFFER_CAP + swap - swap outputfd fputs
    end
    drop
 end
@@ -85,93 +86,109 @@ proc push_op int int -- --
 end
 
 proc compile_ops -- --
-    "BITS 64\n" puts
-    "segment .text\n" puts
-    "dump:\n" puts
-    "    push    rbp\n" puts
-    "    mov     rbp, rsp\n" puts
-    "    sub     rsp, 64\n" puts
-    "    mov     QWORD [rbp-56], rdi\n" puts
-    "    mov     QWORD [rbp-8], 1\n" puts
-    "    mov     eax, 32\n" puts
-    "    sub     rax, QWORD [rbp-8]\n" puts
-    "    mov     BYTE [rbp-48+rax], 10\n" puts
-    ".L2:\n" puts
-    "    mov     rcx, QWORD [rbp-56]\n" puts
-    "    mov     rdx, -3689348814741910323\n" puts
-    "    mov     rax, rcx\n" puts
-    "    mul     rdx\n" puts
-    "    shr     rdx, 3\n" puts
-    "    mov     rax, rdx\n" puts
-    "    sal     rax, 2\n" puts
-    "    add     rax, rdx\n" puts
-    "    add     rax, rax\n" puts
-    "    sub     rcx, rax\n" puts
-    "    mov     rdx, rcx\n" puts
-    "    mov     eax, edx\n" puts
-    "    lea     edx, [rax+48]\n" puts
-    "    mov     eax, 31\n" puts
-    "    sub     rax, QWORD [rbp-8]\n" puts
-    "    mov     BYTE [rbp-48+rax], dl\n" puts
-    "    add     QWORD [rbp-8], 1\n" puts
-    "    mov     rax, QWORD [rbp-56]\n" puts
-    "    mov     rdx, -3689348814741910323\n" puts
-    "    mul     rdx\n" puts
-    "    mov     rax, rdx\n" puts
-    "    shr     rax, 3\n" puts
-    "    mov     QWORD [rbp-56], rax\n" puts
-    "    cmp     QWORD [rbp-56], 0\n" puts
-    "    jne     .L2\n" puts
-    "    mov     eax, 32\n" puts
-    "    sub     rax, QWORD [rbp-8]\n" puts
-    "    lea     rdx, [rbp-48]\n" puts
-    "    lea     rcx, [rdx+rax]\n" puts
-    "    mov     rax, QWORD [rbp-8]\n" puts
-    "    mov     rdx, rax\n" puts
-    "    mov     rsi, rcx\n" puts
-    "    mov     edi, 1\n" puts
-    "    mov     rax, 1\n" puts
-    "    syscall\n" puts
-    "    nop\n" puts
-    "    leave\n" puts
-    "    ret\n" puts
-    "global _start\n" puts
-    "_start:\n" puts
+
+    O_RDWR O_CREAT O_TRUNC | |
+    "./output.asm\x00" swap drop
+    AT_FDCWD
+    openat
+
+    if dup 0 < do
+        "error: could not open file " eputs "./output.asm\n" eputs
+        1 exit
+    end
+    dup MODE0666
+    swap
+    fchmod drop
+
+    outputfd swap .64
+
+    "BITS 64\n" outputfd fputs
+    "segment .text\n" outputfd fputs
+    "dump:\n" outputfd fputs
+    "    push    rbp\n" outputfd fputs
+    "    mov     rbp, rsp\n" outputfd fputs
+    "    sub     rsp, 64\n" outputfd fputs
+    "    mov     QWORD [rbp-56], rdi\n" outputfd fputs
+    "    mov     QWORD [rbp-8], 1\n" outputfd fputs
+    "    mov     eax, 32\n" outputfd fputs
+    "    sub     rax, QWORD [rbp-8]\n" outputfd fputs
+    "    mov     BYTE [rbp-48+rax], 10\n" outputfd fputs
+    ".L2:\n" outputfd fputs
+    "    mov     rcx, QWORD [rbp-56]\n" outputfd fputs
+    "    mov     rdx, -3689348814741910323\n" outputfd fputs
+    "    mov     rax, rcx\n" outputfd fputs
+    "    mul     rdx\n" outputfd fputs
+    "    shr     rdx, 3\n" outputfd fputs
+    "    mov     rax, rdx\n" outputfd fputs
+    "    sal     rax, 2\n" outputfd fputs
+    "    add     rax, rdx\n" outputfd fputs
+    "    add     rax, rax\n" outputfd fputs
+    "    sub     rcx, rax\n" outputfd fputs
+    "    mov     rdx, rcx\n" outputfd fputs
+    "    mov     eax, edx\n" outputfd fputs
+    "    lea     edx, [rax+48]\n" outputfd fputs
+    "    mov     eax, 31\n" outputfd fputs
+    "    sub     rax, QWORD [rbp-8]\n" outputfd fputs
+    "    mov     BYTE [rbp-48+rax], dl\n" outputfd fputs
+    "    add     QWORD [rbp-8], 1\n" outputfd fputs
+    "    mov     rax, QWORD [rbp-56]\n" outputfd fputs
+    "    mov     rdx, -3689348814741910323\n" outputfd fputs
+    "    mul     rdx\n" outputfd fputs
+    "    mov     rax, rdx\n" outputfd fputs
+    "    shr     rax, 3\n" outputfd fputs
+    "    mov     QWORD [rbp-56], rax\n" outputfd fputs
+    "    cmp     QWORD [rbp-56], 0\n" outputfd fputs
+    "    jne     .L2\n" outputfd fputs
+    "    mov     eax, 32\n" outputfd fputs
+    "    sub     rax, QWORD [rbp-8]\n" outputfd fputs
+    "    lea     rdx, [rbp-48]\n" outputfd fputs
+    "    lea     rcx, [rdx+rax]\n" outputfd fputs
+    "    mov     rax, QWORD [rbp-8]\n" outputfd fputs
+    "    mov     rdx, rax\n" outputfd fputs
+    "    mov     rsi, rcx\n" outputfd fputs
+    "    mov     edi, 1\n" outputfd fputs
+    "    mov     rax, 1\n" outputfd fputs
+    "    syscall\n" outputfd fputs
+    "    nop\n" outputfd fputs
+    "    leave\n" outputfd fputs
+    "    ret\n" outputfd fputs
+    "global _start\n" outputfd fputs
+    "_start:\n" outputfd fputs
     0 while dup ops-count ,64 < do
         dup sizeof(Op) * ops +
         if dup ,64 OP_PUSH_INT = do
-            "    ;; -- push int " puts dup 8 + ,64 putd " --\n" puts
-            "    mov rax, " puts dup 8 + ,64 putd "\n" puts
-            "    push rax\n" puts
+            "    ;; -- push int " outputfd fputs dup 8 + ,64 fputd " --\n" outputfd fputs
+            "    mov rax, " outputfd fputs dup 8 + ,64 fputd "\n" outputfd fputs
+            "    push rax\n" outputfd fputs
         elif dup ,64 OP_PLUS = do
-            "    ;; -- plus --\n" puts
-            "    pop rax\n" puts
-            "    pop rbx\n" puts
-            "    add rax, rbx\n" puts
-            "    push rax\n" puts
+            "    ;; -- plus --\n" outputfd fputs
+            "    pop rax\n" outputfd fputs
+            "    pop rbx\n" outputfd fputs
+            "    add rax, rbx\n" outputfd fputs
+            "    push rax\n" outputfd fputs
         elif dup ,64 OP_MINUS = do
-            "    ;; -- minus --\n" puts
-            "    pop rax\n" puts
-            "    pop rbx\n" puts
-            "    sub rbx, rax\n" puts
-            "    push rbx\n" puts
+            "    ;; -- minus --\n" outputfd fputs
+            "    pop rax\n" outputfd fputs
+            "    pop rbx\n" outputfd fputs
+            "    sub rbx, rax\n" outputfd fputs
+            "    push rbx\n" outputfd fputs
         elif dup ,64 OP_DUMP = do
-            "    ;; -- dump --\n" puts
-            "    pop rdi\n" puts
-            "    call dump\n" puts
+            "    ;; -- dump --\n" outputfd fputs
+            "    pop rdi\n" outputfd fputs
+            "    call dump\n" outputfd fputs
         else 
-            here eputs ": unreachable\n" eputs 1 exit
+            here eputs , write drop ": unreachable\n" eputs 1 exit
         end
         drop
         1 +
     end
     drop
-    "    mov rax, 60\n" puts
-    "    mov rdi, 0\n" puts
-    "    syscall\n" puts
-    "segment .data\n" puts
-    "segment .bss\n" puts
-    "mem: resb " puts MEM_CAPACITY putd "\n" puts
+    "    mov rax, 60\n" outputfd fputs
+    "    mov rdi, 0\n" outputfd fputs
+    "    syscall\n" outputfd fputs
+    "segment .data\n" outputfd fputs
+    "segment .bss\n" outputfd fputs
+    "mem: resb " outputfd fputs MEM_CAPACITY fputd "\n" outputfd fputs
 end
 
 proc dump_ops -- --

--- a/goof.goof
+++ b/goof.goof
@@ -25,7 +25,7 @@ memory ops         0 end
 const sizeof(Op) 16 end
 
 // 10 -> "10"
-proc fputd int ptr -- --
+proc fputd int -- --
     if dup 0 = do
         "0" outputfd fputs
     else

--- a/goof.goof
+++ b/goof.goof
@@ -3,6 +3,7 @@ include "string.goof"
 
 const PUTD_BUFFER_CAP 32 end
 const MEM_CAPACITY    640000 end
+const sizeof(ptr)     8 end
 
 const OP_PUSH_INT 0 end
 const OP_PLUS     1 end
@@ -12,6 +13,8 @@ const OP_DUMP     3 end
 memory putd-buffer PUTD_BUFFER_CAP end
 memory fd          8 end
 memory outputfd    8 end
+memory cmd         32 end
+memory wstatus     64 end
 memory statbuf     sizeof(stat) end
 memory content     sizeof(str) end
 memory line        sizeof(str) end
@@ -191,6 +194,82 @@ proc compile_ops -- --
     "mem: resb " outputfd fputs MEM_CAPACITY fputd "\n" outputfd fputs
 end
 
+proc compile_binary -- --
+
+    cmd 0 + "/usr/bin/nasm\x00" swap drop .64
+    cmd 8 + "-felf64\x00" swap drop .64
+    cmd 16 + "output.asm\x00" swap drop .64
+    
+    fork 
+    if dup 0 = do
+        // child process (pid = 0)
+        "[CMD] " puts
+        0 while dup 3 < do
+            dup sizeof(ptr) * cmd + ,64 (ptr) dup strlen swap puts
+            " " puts
+            1 +
+        end
+        drop
+        "\n" puts
+    
+        0 cmd cmd ,64 execve drop
+    elif dup 0 > do
+        // parent process
+        0
+        0
+        wstatus
+        -1
+        wait4
+        if dup 0 < do
+            "[ERROR] could not wait until the child process has finished executing\n" eputs
+            1 exit
+        end
+        drop
+    
+        // "[PARENT] waiting for child completes\n" eputs
+    else
+        "[ERROR] could not fork a child process\n" eputs
+    end
+    drop
+
+    cmd 0 + "/usr/bin/ld\x00" swap drop .64
+    cmd 8 + "-o\x00" swap drop .64
+    cmd 16 + "output\x00" swap drop .64
+    cmd 24 + "output.o\x00" swap drop .64
+    
+    fork 
+    if dup 0 = do
+        // child process (pid = 0)
+        "[CMD] " puts
+        0 while dup 4 < do
+            dup sizeof(ptr) * cmd + ,64 (ptr) dup strlen swap puts
+            " " puts
+            1 +
+        end
+        drop
+        "\n" puts
+    
+        0 cmd cmd ,64 execve drop
+    elif dup 0 > do
+        // parent process
+        0
+        0
+        wstatus
+        -1
+        wait4
+        if dup 0 < do
+            "[ERROR] could not wait until the child process has finished executing\n" eputs
+            1 exit
+        end
+        drop
+    
+        // "[PARENT] waiting for child completes\n" eputs
+    else
+        "[ERROR] could not fork a child process\n" eputs
+    end
+    drop
+end
+
 proc dump_ops -- --
     0 while dup ops-count ,64 < do
         dup sizeof(Op) * ops +
@@ -271,4 +350,5 @@ end
 
 
 compile_ops
+compile_binary
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -21,7 +21,7 @@ var consts = make(map[string]int64)
 var procs = make(map[string]int)
 
 func ParseTokenAsOp(token model.Token) model.Operation {
-    if constants.COUNT_OPS != 56 {
+    if constants.COUNT_OPS != 57 {
         panic("Exhaustive handling in parseTokenAsOp")
     }
 
@@ -117,7 +117,7 @@ func compileTokenList(tokenList []model.Token) []model.Operation {
     var program []model.Operation
     memoryPtr := 0
 
-    if constants.COUNT_OPS != 56 {
+    if constants.COUNT_OPS != 57 {
         panic("Exhaustive handling inside compileTokenList")
     }
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -21,7 +21,7 @@ var consts = make(map[string]int64)
 var procs = make(map[string]int)
 
 func ParseTokenAsOp(token model.Token) model.Operation {
-    if constants.COUNT_OPS != 55 {
+    if constants.COUNT_OPS != 56 {
         panic("Exhaustive handling in parseTokenAsOp")
     }
 
@@ -117,7 +117,7 @@ func compileTokenList(tokenList []model.Token) []model.Operation {
     var program []model.Operation
     memoryPtr := 0
 
-    if constants.COUNT_OPS != 55 {
+    if constants.COUNT_OPS != 56 {
         panic("Exhaustive handling inside compileTokenList")
     }
 

--- a/std.goof
+++ b/std.goof
@@ -12,9 +12,16 @@ const SYS_FORK 57 end
 const SYS_EXECV 59 end
 const SYS_EXIT 60 end
 const SYS_WAIT4 61 end
+const SYS_FCHMOD 91 end
 const SYS_OPENAT 257 end
 
 const O_RDONLY 0 end
+const O_WRONLY 1 end
+const O_RDWR 2 end
+const O_CREAT 64 end
+const O_TRUNC 512 end
+// printf("%d", (mode_t)0666);
+const MODE0666 436 end
 const AT_FDCWD -100 end
 
 const MAP_PRIVATE 2 end
@@ -23,6 +30,7 @@ const PROT_READ 1 end
 macro write SYS_WRITE syscall3 end
 macro read SYS_READ syscall3 end
 macro openat SYS_OPENAT syscall3 end
+macro fchmod SYS_FCHMOD syscall2 end
 macro mmap SYS_MMAP syscall6 end
 macro fstat SYS_FSTAT syscall2 end
 macro fork SYS_FORK syscall0 end
@@ -110,6 +118,10 @@ end
 
 macro puts
     stdout write drop
+end
+
+macro fputs
+   ,64 write drop
 end
 
 macro eputs

--- a/std.goof
+++ b/std.goof
@@ -8,6 +8,7 @@ const SYS_CLOSE 3 end
 const SYS_FSTAT 5 end
 const SYS_MMAP 9 end
 const SYS_SLEEP 35 end
+const SYS_EXECV 59 end
 const SYS_EXIT 60 end
 const SYS_OPENAT 257 end
 
@@ -22,6 +23,7 @@ macro read SYS_READ syscall3 end
 macro openat SYS_OPENAT syscall3 end
 macro mmap SYS_MMAP syscall6 end
 macro fstat SYS_FSTAT syscall2 end
+macro execve SYS_EXECV syscall3 end
 macro sleep SYS_SLEEP syscall2 end
 macro close SYS_CLOSE syscall1 end
 macro exit SYS_EXIT syscall1 drop end

--- a/std.goof
+++ b/std.goof
@@ -8,6 +8,7 @@ const SYS_CLOSE 3 end
 const SYS_FSTAT 5 end
 const SYS_MMAP 9 end
 const SYS_SLEEP 35 end
+const SYS_FORK 57 end
 const SYS_EXECV 59 end
 const SYS_EXIT 60 end
 const SYS_OPENAT 257 end
@@ -23,6 +24,7 @@ macro read SYS_READ syscall3 end
 macro openat SYS_OPENAT syscall3 end
 macro mmap SYS_MMAP syscall6 end
 macro fstat SYS_FSTAT syscall2 end
+macro fork SYS_FORK syscall0 end
 macro execve SYS_EXECV syscall3 end
 macro sleep SYS_SLEEP syscall2 end
 macro close SYS_CLOSE syscall1 end

--- a/std.goof
+++ b/std.goof
@@ -11,6 +11,7 @@ const SYS_SLEEP 35 end
 const SYS_FORK 57 end
 const SYS_EXECV 59 end
 const SYS_EXIT 60 end
+const SYS_WAIT4 61 end
 const SYS_OPENAT 257 end
 
 const O_RDONLY 0 end
@@ -25,6 +26,7 @@ macro openat SYS_OPENAT syscall3 end
 macro mmap SYS_MMAP syscall6 end
 macro fstat SYS_FSTAT syscall2 end
 macro fork SYS_FORK syscall0 end
+macro wait4 SYS_WAIT4 syscall4 end
 macro execve SYS_EXECV syscall3 end
 macro sleep SYS_SLEEP syscall2 end
 macro close SYS_CLOSE syscall1 end

--- a/tests/execve.goof
+++ b/tests/execve.goof
@@ -1,0 +1,7 @@
+memory cmd  16 end
+
+cmd 0 + "/usr/bin/echo\x00" swap drop .64
+cmd 8 + "hello world\x00" swap drop .64
+
+// NULL ["/usr/bin/echo", "hello"] "echo"
+0 cmd cmd ,64 59 syscall3 drop

--- a/tests/execve.goof
+++ b/tests/execve.goof
@@ -1,4 +1,4 @@
-memory cmd  16 end
+memory cmd 16 end
 
 cmd 0 + "/usr/bin/echo\x00" swap drop .64
 cmd 8 + "hello world\x00" swap drop .64

--- a/tests/hello-world.goof
+++ b/tests/hello-world.goof
@@ -1,15 +1,15 @@
-mem dup 72 .
+mem dup 72  .
 1 + dup 101 .
 1 + dup 108 .
 1 + dup 108 .
 1 + dup 111 .
-1 + dup 44 .
-1 + dup 32 .
-1 + dup 87 .
+1 + dup 44  .
+1 + dup 32  .
+1 + dup 87  .
 1 + dup 111 .
 1 + dup 114 .
 1 + dup 108 .
 1 + dup 100 .
-1 + dup 10 .
+1 + dup 10  .
 1 + 
 mem - mem 1 1 syscall3 drop

--- a/types/types.go
+++ b/types/types.go
@@ -96,7 +96,7 @@ func getProcedureInputs(procName string) (string) {
 func TypeCheckingProgram(program []model.Operation) {
     var stack = new(util.Stack[typedOperand])
     var blockStacks = new(util.Stack[blockStack])
-    if constants.COUNT_OPS != 56 {
+    if constants.COUNT_OPS != 57 {
         panic("Exhaustive handling inside TypeCheckingProgram")
     }
     var op model.Operation
@@ -498,6 +498,14 @@ func TypeCheckingProgram(program []model.Operation) {
             stack.Push(typedOperand{ TYPE_INT, op.FilePath, op.Row })
         case constants.OP_SYSCALL3:
             util.CheckNumberOfArguments(stack.Size(), 4, op, "syscall3")
+            _ = stack.Pop()
+            _ = stack.Pop()
+            _ = stack.Pop()
+            _ = stack.Pop()
+            stack.Push(typedOperand{ TYPE_INT, op.FilePath, op.Row })
+        case constants.OP_SYSCALL4:
+            util.CheckNumberOfArguments(stack.Size(), 4, op, "syscall3")
+            _ = stack.Pop()
             _ = stack.Pop()
             _ = stack.Pop()
             _ = stack.Pop()

--- a/types/types.go
+++ b/types/types.go
@@ -96,7 +96,7 @@ func getProcedureInputs(procName string) (string) {
 func TypeCheckingProgram(program []model.Operation) {
     var stack = new(util.Stack[typedOperand])
     var blockStacks = new(util.Stack[blockStack])
-    if constants.COUNT_OPS != 55 {
+    if constants.COUNT_OPS != 56 {
         panic("Exhaustive handling inside TypeCheckingProgram")
     }
     var op model.Operation


### PR DESCRIPTION
`goof.goof` is able to convert valid tokens to assembly for now
This pull request makes `goof.goof` being able to generate the target binary
- write the generated assembly to `output.asm`
- call external programs namely `nasm` and `ld` to compile the assembly to binary